### PR TITLE
feat: 使用更准确的后缀！

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -3,6 +3,7 @@
  * @description 标准化路径
  */
 const path = require('path')
+const fs = require('fs')
 
 function normalizePath(p) {
   if (typeof p !== 'string') throw new TypeError('Path must be a string')
@@ -10,4 +11,25 @@ function normalizePath(p) {
   return p.split(path.sep).join('/')
 }
 
-module.exports = { normalizePath }
+/**
+ * 
+ * @author LinLeung
+ * @description 提取正确路径 
+ */
+
+function normalizeTransPath(normalizedPath, modulePath) {
+  try {
+    const tempSuffix = modulePath.match(/\/((?!\/).)*$/)
+    const suffixSplit = normalizedPath.split(tempSuffix[0])
+
+    return modulePath
+      .replace(
+        tempSuffix[0],
+        `${tempSuffix[0]}${suffixSplit[suffixSplit.length - 1]}`
+      ) || modulePath + '.vue';
+  } catch(error) {
+    return modulePath + '.vue'
+  }
+}
+
+module.exports = { normalizePath, normalizeTransPath }

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -9,7 +9,7 @@ const generate = require('@babel/generator').default
 const t = require('@babel/types')
 
 const { succ, warn } = require('./log')
-const { normalizePath } = require('./normalize')
+const { normalizePath, normalizeTransPath } = require('./normalize')
 const { createMyResolver } = require('./resolver')
 
 module.exports = class Transformer {
@@ -153,7 +153,7 @@ module.exports = class Transformer {
           )
 
         return this.isHitted(normalizedPath)
-          ? input.replace(modulePath, modulePath + '.vue')
+          ? input.replace(modulePath, normalizeTransPath(normalizedPath, modulePath))
           : input
       } catch (error) {
         return input


### PR DESCRIPTION
使用resolver得到的文件path，然后进行正则的提取和替换，来兼容index.vue或者index.js的情况